### PR TITLE
fix: enable the proxy_cache_path

### DIFF
--- a/install
+++ b/install
@@ -13,7 +13,7 @@ plugin-install() {
   ## INSTALLED BY DOKKU PLUGIN.
   ## Please visit https://github.com/kvandake/dokku-nginx-cache for more info
   ####
-  # proxy_cache_path /var/cache/nginx levels=1:2 keys_zone=dokku:10m inactive=60m use_temp_path=off;
+  proxy_cache_path /var/cache/nginx levels=1:2 keys_zone=dokku:10m inactive=60m use_temp_path=off;
   add_header X-Cache-Status \$upstream_cache_status;
 
 EOF


### PR DESCRIPTION
Without this, there are errors reloading the nginx config as the dokku cache bucket isn't available.